### PR TITLE
feat(ci): Add common workflows

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,0 +1,23 @@
+name: "Conventional PR title"
+
+on:
+  workflow_call:
+    inputs:
+      validateSingleCommit:
+        description: 'Whether to validate single commit PR'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  conventional_title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          validateSingleCommit: ${{ inputs.validateSingleCommit }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -73,6 +73,38 @@ jobs:
             echo "Validation failed, you should upgrade the chart version in Chart.yaml"
             exit 1
           fi
+      - name: Check for version and date in CHANGELOG
+        run: |
+          VERSION_PATTERN="([0-9]+\.){2}[0-9]+"
+          DATE_PATTERN="[0-9]{4}-[0-9]{2}-[0-9]{2}"
+          HEADING_PATTERN="## \[${VERSION_PATTERN}\] - ${DATE_PATTERN}"
+          CHANGELOG="${{ needs.prepare-charts-path.outputs.charts_path }}/CHANGELOG.md"
+          VERSION=$(grep '^version:' ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml | awk '{print $2}')
+
+          VERSION_DATE=$(grep -E "${HEADING_PATTERN}" ${CHANGELOG}) 
+
+          VERSION_DATE=$(echo "$VERSION_DATE" | grep "${VERSION}" || true)
+          
+          if [[ -z "$VERSION_DATE" ]]; then
+            echo "$CHANGELOG does not contain an entry for version ${VERSION}" && exit 1
+          fi
+
+          VERSION_DATE=$((echo "$VERSION_DATE" | grep -oE "${DATE_PATTERN}") || true)
+
+          if [[ -z "$VERSION_DATE" ]]; then
+            echo "${CHANGELOG} does not contain the correct format for version $VERSION." && exit 1
+          fi
+
+          ALL_DATES=$(grep -E "${HEADING_PATTERN}" ${CHANGELOG} | grep -oE "${DATE_PATTERN}")
+
+          LATEST_DATE=$(echo "$ALL_DATES" | sort -r | head -n 1)
+
+          if [[ "$VERSION_DATE" == "$LATEST_DATE" ]]; then
+            echo "${CHANGELOG} updated correctly with version $VERSION and date $VERSION_DATE is the latest."
+          else
+            echo "The date $VERSION_DATE associated with version $VERSION is not the latest in the ${CHANGELOG}. Latest date is $LATEST_DATE." && exit 1
+          fi
+
       - name: Validate Chart.lock changes
         run: |
           DIR=${{ needs.prepare-charts-path.outputs.charts_path }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,169 @@
+name: Helm
+
+on:
+  workflow_call:
+    inputs:
+        charts-path:
+            type: string
+            required: false
+            description: The path of the Charts directory, defaults to charts/<repo>
+        charts-name:
+            type: string
+            description: The name of charts, defaults to {{ github.repository }} <owner>/<repository>
+            default: ${{ github.repository }}
+            required: false
+        path:
+            type: string
+            description: The path for the output folder of clone
+            default: ${{ github.repository_id }}
+            required: false
+        helm-repositories:
+            description: 'JSON-encoded list of Helm repositories.'
+            required: true
+            type: string
+
+jobs:
+  prepare-charts-path:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set default charts-path if not provided
+      id: set-path
+      run: |
+        REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f2)
+        echo "repo=$REPO_NAME" >> $GITHUB_OUTPUT
+        if [ -z "${{ inputs.charts-path }}" ]; then
+          echo "path=./charts/$REPO_NAME" >> $GITHUB_OUTPUT
+        else
+          echo "path=${{inputs.charts-path}}" >> $GITHUB_OUTPUT
+        fi
+    outputs:
+      charts_path: ${{ steps.set-path.outputs.path }}
+      repository_name: ${{ steps.set-path.outputs.repo }}
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: prepare-charts-path
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v3.5
+        with:
+          version: "v3.12.0"
+        id: install
+
+      - name: Install tools
+        run: |
+          sudo snap install yq
+
+      - name: Build dependencies
+        run: helm dep update ${{ needs.prepare-charts-path.outputs.charts_path }}
+
+      - name: Lint Chart
+        run: helm lint ${{ needs.prepare-charts-path.outputs.charts_path }}
+
+      - name: Validate version increment
+        run: |
+          helm repo add substra https://substra.github.io/charts
+
+          RES=$(helm search repo ${{ inputs.charts-name }} --version $(yq eval .version ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml))
+
+          if [ "${RES}" == "No results found" ]; then
+            echo "Version incremented"
+          else
+            echo "Validation failed, you should upgrade the chart version in Chart.yaml"
+            exit 1
+          fi
+      - name: Validate Chart.lock changes
+        run: |
+          DIR=${{ needs.prepare-charts-path.outputs.charts_path }}
+          helm dependency update $DIR
+          git diff --exit-code $DIR/Chart.lock || (echo "$DIR/Chart.lock needs to be updated!" >&2 && exit 1)
+          
+
+  generate-chart-readme:
+    runs-on: ubuntu-latest
+    needs: prepare-charts-path
+    steps:
+      - name: Checkout bitnami-labs/readme-generator-for-helm
+        uses: actions/checkout@v4
+        with:
+          repository: "bitnami-labs/readme-generator-for-helm"
+          ref: "2.5.0"
+          path: readme-generator-for-helm
+
+      - name: Install readme-generator-for-helm dependencies
+        run: cd readme-generator-for-helm && npm install
+
+      - uses: actions/checkout@v4
+        with:
+          path: ${{inputs.path}}
+
+      - name: Execute readme-generator-for-helm
+        run: |
+            CHARTS_DIR=${{inputs.path}}/${{needs.prepare-charts-path.outputs.charts_path}} 
+            readme-generator-for-helm/bin/index.js -r ${CHARTS_DIR}/README.md -v ${CHARTS_DIR}/values.yaml
+
+      - name: Check diff
+        run: |
+          cd ${{inputs.path}}/
+          if [ -z "$(git status --porcelain)" ]; then
+            exit 0
+          else
+            echo "There should be no change generated, please run 'make doc' in ${{inputs.path}}/charts/ to update the chart README.md"
+            git diff
+            exit 1
+          fi
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs:
+      - prepare-charts-path
+      - test
+      - generate-chart-readme
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+            sudo snap install yq
+
+      - uses: azure/setup-helm@v3.5
+        with:
+          version: "v3.12.0"
+        id: install
+
+      - name: Add dependencies repo
+        run: |
+          REPOS_JSON="${{ inputs.helm-repositories }}"
+          echo "$REPOS_JSON" | jq -c '.[]' | while read repo; do
+            name=$(echo "$repo" | jq -r '.name')
+            url=$(echo "$repo" | jq -r '.url')
+            helm repo add "$name" "$url"
+          done
+
+      - name: Package chart
+        run: |
+          CHARTS_PATH=${{ needs.prepare-charts-path.outputs.charts_path }}
+          helm dep build ${CHARTS_PATH}
+          helm package ${CHARTS_PATH}
+
+      - name: Clone Substra charts
+        uses: actions/checkout@v4
+        with:
+          repository: Substra/charts
+          ref: "main"
+          token: ${{ secrets.CHARTS_GITHUB_TOKEN }}
+          path: substra-charts
+
+      - name: Publish chart
+        run: |
+          mv ${{ needs.prepare-charts-path.outputs.repository_name }}-$(grep -e "^version" ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml | cut -c10-).tgz substra-charts/
+          cd substra-charts
+          helm repo index .
+          git add .
+          git config --global user.email "gh-actions@github.com"
+          git config --global user.name "GitHub Action"
+          git commit -s --message "GitHub Action: ${{ github.repository }}@${{ github.sha }}"
+          git push --quiet --set-upstream origin main

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -39,33 +39,42 @@ jobs:
     outputs:
       charts_path: ${{ steps.set-path.outputs.path }}
       repository_name: ${{ steps.set-path.outputs.repo }}
-  test:
-    name: Tests
+  lint:
+    name: Lints
+    runs-on: ubuntu-latest
+    needs: prepare-charts-path
+    steps:
+        - uses: actions/checkout@v4
+        - uses: azure/setup-helm@v3.5
+          with:
+            version: "v3.12.0"
+          id: install
+        - name: Build dependencies
+          run: helm dep update ${{ needs.prepare-charts-path.outputs.charts_path }}
+        - name: Lint Chart
+          run: helm lint ${{ needs.prepare-charts-path.outputs.charts_path }}
+  test-if-version-changed:
+    name: Tests if the Chart version is updated and CHANGELOG is updated for the version
     runs-on: ubuntu-latest
     needs: prepare-charts-path
     steps:
       - uses: actions/checkout@v4
-
       - uses: azure/setup-helm@v3.5
         with:
           version: "v3.12.0"
         id: install
 
       - name: Install tools
+        run: sudo snap install yq
+      - name: Get Chart version
         run: |
-          sudo snap install yq
-
-      - name: Build dependencies
-        run: helm dep update ${{ needs.prepare-charts-path.outputs.charts_path }}
-
-      - name: Lint Chart
-        run: helm lint ${{ needs.prepare-charts-path.outputs.charts_path }}
-
+          echo CHART_VERSION=$(yq eval .version ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml) >> $GITHUB_OUTPUT
+        id: get-chart-version
       - name: Validate version increment
         run: |
           helm repo add substra https://substra.github.io/charts
 
-          RES=$(helm search repo ${{ inputs.charts-name }} --version $(yq eval .version ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml))
+          RES=$(helm search repo ${{ inputs.charts-name }} --version ${{ steps.get-chart-version.outputs.CHART_VERSION }})
 
           if [ "${RES}" == "No results found" ]; then
             echo "Version incremented"
@@ -79,7 +88,7 @@ jobs:
           DATE_PATTERN="[0-9]{4}-[0-9]{2}-[0-9]{2}"
           HEADING_PATTERN="## \[${VERSION_PATTERN}\] - ${DATE_PATTERN}"
           CHANGELOG="${{ needs.prepare-charts-path.outputs.charts_path }}/CHANGELOG.md"
-          VERSION=$(grep '^version:' ${{ needs.prepare-charts-path.outputs.charts_path }}/Chart.yaml | awk '{print $2}')
+          VERSION=${{ steps.get-chart-version.outputs.CHART_VERSION }}
 
           VERSION_DATE=$(grep -E "${HEADING_PATTERN}" ${CHANGELOG}) 
 
@@ -104,14 +113,26 @@ jobs:
           else
             echo "The date $VERSION_DATE associated with version $VERSION is not the latest in the ${CHANGELOG}. Latest date is $LATEST_DATE." && exit 1
           fi
+  test-lock-file:
+    name: Test if Chart.lock file needs to be updated
+    runs-on: ubuntu-latest
+    needs: prepare-charts-path
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v3.5
+        with:
+          version: "v3.12.0"
+        id: install
+
+      - name: Build dependencies
+        run: helm dep update ${{ needs.prepare-charts-path.outputs.charts_path }}
 
       - name: Validate Chart.lock changes
         run: |
           DIR=${{ needs.prepare-charts-path.outputs.charts_path }}
-          helm dependency update $DIR
           git diff --exit-code $DIR/Chart.lock || (echo "$DIR/Chart.lock needs to be updated!" >&2 && exit 1)
-          
-
+  
   generate-chart-readme:
     runs-on: ubuntu-latest
     needs: prepare-charts-path
@@ -152,7 +173,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
       - prepare-charts-path
-      - test
+      - lint
+      - test-if-version-changed
+      - test-lock-file
       - generate-chart-readme
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Added

- A generic Helm workflow that works both for `orchestrator` and `substra-backend`
- A generic `conventional-pr` workflow 
- Extended the Helm workflow to check if the Chart.lock file should be updated.  ( Tested in https://github.com/Substra/substra-backend/actions/runs/6581016432 and https://github.com/Substra/orchestrator/actions/runs/6580084067  )   
- A GitHub action checks if the CHANGELOG is updated with the new version number and if its date is the latest one of the CHANGELOG 

## Changed

- Existing Helm workflow refactored to multiple jobs it reduces the total run time for the workflow