### PR TITLE
chore(.github/workflows/helm): test helm package during pre-merge

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Check readme
         run: |
-          CHARTS_DIR="$PWD/${{needs.set-path.outputs.charts_path}}"
+          CHARTS_DIR="${{needs.set-path.outputs.charts_path}}"
           if [[ ! -e $DIR/README.md ]]; then
             echo "::warning:: $DIR/README.md file not found"
           else
@@ -151,6 +151,12 @@ jobs:
             fi
           
           fi
+
+      - name: Helm package
+        run: |
+          CHARTS_PATH=${{ needs.set-path.outputs.charts_path }}
+          helm dep build ${CHARTS_PATH}
+          helm package ${CHARTS_PATH}
 
   publish:
     name: Publish


### PR DESCRIPTION
See https://github.com/Substra/substra-backend/actions/runs/8098000086/job/22130391393

Where `Test` job is successful but `Publish` fails. Adding the helm package step into the `Tests` jobs should prevent this from happening again. 