### PR TITLE
chore(.github/workflows): make publish condition more robust

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -183,7 +183,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Allowing manual workflow_dispatch on main branches as version is always verified
-    if: ${{inputs.publish-alpha}} || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
+    if: (${{ inputs.publish-alpha == 'true' }} && github.event_name == 'workflow_dispatch') || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
     needs:
       - set-path
       - tests


### PR DESCRIPTION
# Issue 

Chart publication is occurring in pre-merge phase:
* See details of PR https://github.com/Substra/substra-backend/pull/889
* And associated Helm job: https://github.com/Substra/substra-backend/actions/runs/8699322456/job/23857773590
* And post-merge Helm job failing: https://github.com/Substra/substra-backend/actions/runs/8700072270/job/23859694537

# Details

Taking a look at the workflow, we can see that the input value for publish-alpha is `false` which means this part is working as expected. We can assume the condition: 
```yaml 
${{ inputs.publish-alpha }}
```
Is not.